### PR TITLE
Fix import path

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import { filterFalsy } from 'src'
+import { filterFalsy } from './utils'
 import type { ApiClient } from './endpoints'
 import { VTubeStudioError, ErrorCode } from './types'
 


### PR DESCRIPTION
I got import path error below with  using vtubestudio version `1.8.0` and `1.9.0` at webpack build phase. `1.6.1` works fine for me.

```
ERROR in ./node_modules/vtubestudio/lib/plugin.js 71:12-26
Module not found: Error: Can't resolve 'src' in '/Users/satetsu888/work/vts-plugin/node_modules/vtubestudio/lib'
...
```

It seems to be simple miss typing, so patched.