### PR TITLE
Fix InjectParameterDataEndpoint, make faceFound and mode optional params

### DIFF
--- a/src/endpoints.ts
+++ b/src/endpoints.ts
@@ -274,8 +274,8 @@ interface ParameterDeletionEndpoint extends IApiEndpoint<'ParameterDeletion', {
 }> { }
 
 interface InjectParameterDataEndpoint extends IApiEndpoint<'InjectParameterData', {
-    faceFound: boolean
-    mode: 'set' | 'add'
+    faceFound?: boolean
+    mode?: 'set' | 'add'
     parameterValues: {
         id: string
         weight?: number


### PR DESCRIPTION
In the InjectParameterData API, `faceFound` and `mode` are optional parameters, according to the document.
https://github.com/DenchiSoft/VTubeStudio#feeding-in-data-for-default-or-custom-parameters

Confirmed that it works without passing `faceFound` and `mode` in VTubeStudio 1.21.11 .
