### PR TITLE
Fix validation implementation

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -29,12 +29,11 @@ export function validate<T>(value: T, name: string, schema: ValidationSchema<T>)
             for (let i = 0; i < value.length; i++) validate(value[i], `${name}[${i}]`, subSchema as any)
         } else if (type === 'object') {
             if (typeof value !== 'object') throw new Error(`${name} must be an object (got ${typeof value} instead)`)
-            for (const k in schema) {
-                if (!(k in value)) throw new Error(`${name}.${k} must be set`)
-                validate((value as any)[k], `${name}.${k}`, (schema as any)[k])
+            for (const k in subSchema) {
+                validate((value as any)[k], `${name}.${k}`, (subSchema as any)[k])
             }
             for (const k in value) {
-                if (!(k in schema)) throw new Error(`${name}.${k} must not be set`)
+                if (!(k in (subSchema as any))) throw new Error(`${name}.${k} must not be set`)
             }
         }
     }


### PR DESCRIPTION
Hi, I got below error during initialize ApiClient

```
Uncaught (in promise) Error: options.0 must be set
    at validate (validation.js?9521:42:1)
    at new ApiClient (endpoints.js?7cbd:91:1)
    ...
```


A code for validating `object` type in array schema seems not working correctly.
`schema` is array and it looks like `['object', {...}]`, so we need to use subSchema to check each attributes and to call validation method recursively.

I also think, need some test code for that complex method if possible.