### PR TITLE
Add public disconnect method

### DIFF
--- a/examples/vts-react-test/package-lock.json
+++ b/examples/vts-react-test/package-lock.json
@@ -14,8 +14,17 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
-        "vtubestudio": "^3.0.0-beta.4",
+        "vtubestudio": "^3.0.0",
         "web-vitals": "^2.1.4"
+      }
+    },
+    "../..": {
+      "name": "vtubestudio",
+      "version": "3.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typedoc": "^0.23.10",
+        "typescript": "^4.7.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -15721,9 +15730,8 @@
       }
     },
     "node_modules/vtubestudio": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/vtubestudio/-/vtubestudio-3.0.0-beta.4.tgz",
-      "integrity": "sha512-HHTcksdmFXB0fbDZcRpu9oDdxdOw22UTET/oXdnWG0jZ7dTx3UX+2D+ouOIge5Z4o9+DqPMesnx8VfST4asoMQ=="
+      "resolved": "../..",
+      "link": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -27729,9 +27737,11 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vtubestudio": {
-      "version": "3.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/vtubestudio/-/vtubestudio-3.0.0-beta.4.tgz",
-      "integrity": "sha512-HHTcksdmFXB0fbDZcRpu9oDdxdOw22UTET/oXdnWG0jZ7dTx3UX+2D+ouOIge5Z4o9+DqPMesnx8VfST4asoMQ=="
+      "version": "file:../..",
+      "requires": {
+        "typedoc": "^0.23.10",
+        "typescript": "^4.7.4"
+      }
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/examples/vts-react-test/src/App.js
+++ b/examples/vts-react-test/src/App.js
@@ -43,6 +43,9 @@ function App() {
       setModelName(modelName)
     })
 
+    return () => {
+      apiClient.disconnect()
+    }
   }, [])
 
   return (


### PR DESCRIPTION
I took a slightly different approach from what I discussed originally since this is less disruptive. 

Before adding this method, due to React's strict mode, the react example would open 2 WebSocket connections to VTS, but now we can ensure only 1 connection is open at any time.

Resolves #12 